### PR TITLE
Added preferences screen, and added default behaviour to Share activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,8 +20,17 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
+            </intent-filter>                                             
+                                    
+        </activity>
+        
+        <activity
+            android:excludeFromRecents="true"
+            android:name="ViewAndUpdatePreferencesActivity" >    
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
         </activity>
     </application>
 

--- a/app/src/main/java/oss/abnd/volumiospotifyhelper/ViewAndUpdatePreferencesActivity.java
+++ b/app/src/main/java/oss/abnd/volumiospotifyhelper/ViewAndUpdatePreferencesActivity.java
@@ -1,0 +1,75 @@
+package oss.abnd.volumiospotifyhelper;
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+
+public class ViewAndUpdatePreferencesActivity extends Activity {
+
+	public static final String IP_VOLUMIO = "ipvolumio";
+	public static final String REPLACE_PLAYLIST = "replacePlaylist";
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		setContentView(R.layout.user_prefs_fragment);
+
+	}
+
+	// Fragment that displays the username preference
+	public static class UserPreferenceFragment extends PreferenceFragment {
+
+		protected static final String TAG = "UserPrefsFragment";
+		private OnSharedPreferenceChangeListener mListener;
+		private Preference mIPVolumioPreference;
+		private Preference mReplacePlaylistPreference;
+//		private Preference mCaptionsPreference;
+
+		@Override
+		public void onCreate(Bundle savedInstanceState) {
+			super.onCreate(savedInstanceState);
+
+			// Load the preferences from an XML resource
+			addPreferencesFromResource(R.xml.user_prefs);
+
+			// Get the username Preference
+			mIPVolumioPreference = (Preference) getPreferenceManager()
+					.findPreference(IP_VOLUMIO);
+//			mIntervalPreference = (Preference) getPreferenceManager()
+//					.findPreference(INTERVAL);
+			mReplacePlaylistPreference = (Preference) getPreferenceManager()
+					.findPreference(REPLACE_PLAYLIST);
+
+			// Attach a listener to update summary when username changes
+			mListener = new OnSharedPreferenceChangeListener() {
+				@Override
+				public void onSharedPreferenceChanged(
+						SharedPreferences sharedPreferences, String key) {
+					mIPVolumioPreference.setSummary(sharedPreferences.getString(
+							IP_VOLUMIO, "None Set"));
+//					mIntervalPreference.setSummary(sharedPreferences.getString(
+//							INTERVAL, "None Set"));
+				}
+			};
+
+			// Get SharedPreferences object managed by the PreferenceManager for
+			// this Fragment
+			SharedPreferences prefs = getPreferenceManager()
+					.getSharedPreferences();
+
+			// Register a listener on the SharedPreferences object
+			prefs.registerOnSharedPreferenceChangeListener(mListener);
+
+			// Invoke callback manually to display the current username
+			mListener.onSharedPreferenceChanged(prefs, IP_VOLUMIO);
+//			mListener.onSharedPreferenceChanged(prefs, INTERVAL);
+			mListener.onSharedPreferenceChanged(prefs, REPLACE_PLAYLIST);
+
+		}
+
+	}
+}

--- a/app/src/main/res/layout/user_prefs_fragment.xml
+++ b/app/src/main/res/layout/user_prefs_fragment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/userPreferenceFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    class="oss.abnd.volumiospotifyhelper.ViewAndUpdatePreferencesActivity$UserPreferenceFragment"
+    android:orientation="vertical" >
+
+</fragment>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">VolumioSpotifyHelper</string>
     <string name="title_activity_main">SendToVolumio</string>
     <string name="action_settings">Settings</string>
-    <string name="title_activity_share">Send To Volumio</string>
+    <string name="title_activity_share">Add To Volumio</string>
     <string name="hello_world">Hello world!</string>
     <string name="hostname">Hostname</string>
     <string name="replace_playlist">Replace current playlist.</string>

--- a/app/src/main/res/xml/user_prefs.xml
+++ b/app/src/main/res/xml/user_prefs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="@+id/pref_screen" >
+
+    <EditTextPreference
+        android:dialogMessage="Enter Your Hostname IP"
+        android:dialogTitle="@string/action_settings"
+        android:key="ipvolumio"
+        android:negativeButtonText="Cancel"
+        android:positiveButtonText="Submit"
+        android:title="@string/hostname" 
+        >
+    </EditTextPreference>
+	
+    
+    <CheckBoxPreference
+        android:title="@string/replace_playlist"
+        android:key="replacePlaylist"
+        >
+    </CheckBoxPreference>
+</PreferenceScreen>


### PR DESCRIPTION
This pull request changes the default behavior of Spotio.
It adds a preferences activity where the user can add the IP address of the volumio server and the default behaviour of either Adding or Replacing the current playlist.
It also changes the name of the share activity to "Add to Volumio" to help android put Spotio higher on the sharing applicaitons list.

The main change is that when a user touches on "Add to Spotio", it will simply see a Toast message indicating if the action was successful or not, avoiding thus one touch.
